### PR TITLE
Update organization references to opencadc-metadata-curation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG OPENCADC_PYTHON_VERSION=3.12
-FROM opencadc/matplotlib:${OPENCADC_PYTHON_VERSION}-slim as builder
+FROM opencadc-metadata-curation/matplotlib:${OPENCADC_PYTHON_VERSION}-slim as builder
 
 RUN apt-get update --no-install-recommends && \
     apt-get dist-upgrade -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update --no-install-recommends && \
 WORKDIR /usr/src/app
 
 ARG OPENCADC_BRANCH=main
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 
 RUN git clone https://github.com/${OPENCADC_REPO}/caom2tools.git && \
     cd caom2tools && \

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
    1. In the master branch of this repository, find the scripts directory, and copy the file `state.yml` to the working directory. e.g.:
 
       ```
-      wget https://raw.github.com/opencadc/neossat2caom2/master/scripts/state.yml
+      wget https://raw.github.com/opencadc-metadata-curation/neossat2caom2/master/scripts/state.yml
       ```
    
    1. In the master branch of this repository, find the config directory, and copy the file `config.yml` to the working directory. e.g.:
 
       ```
-      wget https://raw.github.com/opencadc/neossat2caom2/master/config/config.yml
+      wget https://raw.github.com/opencadc-metadata-curation/neossat2caom2/master/config/config.yml
       ```
 
 
    1. In the master branch of this repository, find the scripts directory, and copy the file neossat_run_state.sh to the working directory. e.g.:
 
       ```
-      wget https://raw.github.com/opencadc/neossat2caom2/master/scripts/neossat_run_state.sh
+      wget https://raw.github.com/opencadc-metadata-curation/neossat2caom2/master/scripts/neossat_run_state.sh
       ```
 
    1. Ensure the script is executable:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
 1. The application requires a X509 certificate for authentication and authorization. The following commands will generate a valid 10-day proxy. Note that you will be prompted for the `Password:`
 
    ```
-   docker run --rm -ti --mount "type=bind,src=${PWD},dst=/usr/src/app" opencadc/neossat2caom2 /bin/bash
+   docker run --rm -ti --mount "type=bind,src=${PWD},dst=/usr/src/app" opencadc-metadata-curation/neossat2caom2 /bin/bash
    cadcops@c34e8321f722:/usr/src/app$ cadc-get-cert --days-valid 10 --cert-file /usr/src/app/cadcproxy.pem -u <CADC User Name>
    Password:
    exit

--- a/scripts/neossat_run.sh
+++ b/scripts/neossat_run.sh
@@ -4,7 +4,7 @@ echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?
 
 COLLECTION="neossat"
-CONTAINER="opencadc/${COLLECTION}2caom2"
+CONTAINER="opencadc-metadata-curation/${COLLECTION}2caom2"
 echo "Get the image ${CONTAINER}"
 docker pull ${CONTAINER} || exit $?
 

--- a/scripts/neossat_run_state.sh
+++ b/scripts/neossat_run_state.sh
@@ -4,7 +4,7 @@ echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?
 
 COLLECTION="neossat"
-CONTAINER="opencadc/${COLLECTION}2caom2"
+CONTAINER="opencadc-metadata-curation/${COLLECTION}2caom2"
 echo "Get the image ${CONTAINER}"
 docker pull ${CONTAINER} || exit $?
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/neossat2caom2
+github_project = opencadc-metadata-curation/neossat2caom2
 install_requires = 
   bs4
   cadcdata


### PR DESCRIPTION
This PR updates all references from `opencadc` to `opencadc-metadata-curation` following the repository transfer.

## Changes
- Updated Dockerfile dependencies and base images\n
- Updated README documentation\n
- Updated shell scripts
## Files Modified
```
Dockerfile
README.md
scripts/neossat_run.sh
scripts/neossat_run_state.sh
```

## Related
- Repository migration to opencadc-metadata-curation organization
- Ensures all references point to the correct organization

## Testing
- Verify builds pass
- Verify all references are updated correctly
